### PR TITLE
sendmail fix

### DIFF
--- a/owncloudpie_setup.sh
+++ b/owncloudpie_setup.sh
@@ -172,7 +172,7 @@ function main_newinstall_nginx()
 
 	# install all needed packages, e.g., Apache, PHP, SQLite
   apt-get remove -y apache2
-	apt-get install -y nginx sendmail openssl ssl-cert php5-cli php5-sqlite php5-gd php5-curl php5-common php5-cgi sqlite php-pear php-apc git-core
+	apt-get install -y nginx sendmail sendmail-bin openssl ssl-cert php5-cli php5-sqlite php5-gd php5-curl php5-common php5-cgi sqlite php-pear php-apc git-core
 	apt-get install -y autoconf automake autotools-dev curl libapr1 libtool curl libcurl4-openssl-dev php-xml-parser php5 php5-dev php5-gd php5-fpm
   apt-get install -y apt-get install memcached php5-memcache varnish
   apt-get autoremove -y
@@ -236,7 +236,7 @@ function main_newinstall_apache()
   usermod -a -G www-data www-data
 
   # install all needed packages, e.g., Apache, PHP, SQLite
-  apt-get install -y apache2 openssl sendmail ssl-cert libapache2-mod-php5 php5-cli php5-sqlite php5-gd php5-curl php5-common php5-cgi sqlite php-pear php-apc git-core ca-certificates
+  apt-get install -y apache2 openssl sendmail sendmail-bin ssl-cert libapache2-mod-php5 php5-cli php5-sqlite php5-gd php5-curl php5-common php5-cgi sqlite php-pear php-apc git-core ca-certificates
 
   # Change RAM settings 16 MB video RAM
   ensureKeyValueShort "gpu_mem" "16" "/boot/config.txt"


### PR DESCRIPTION
For me the installation on raspbian without preinstalled webserver environment failed since sendmail requires sendmail-bin to be installed. This resulted in the first apt-get not being executed and though missing nginx and some other stuff.

Fixed by adding sendmail-bin to the installation.
