### PR TITLE
do not remove apache during nginx setup

### DIFF
--- a/owncloudpie_setup.sh
+++ b/owncloudpie_setup.sh
@@ -184,8 +184,7 @@ function main_newinstall_nginx()
 	groupadd www-data
 	usermod -a -G www-data www-data
 
-	# install all needed packages, e.g., Apache, PHP, SQLite
-  apt-get remove -y apache2
+	# install all needed packages, e.g., Nginx, PHP, SQLite
   apt-get install -y nginx sendmail sendmail-bin openssl ssl-cert php5-cli php5-sqlite php5-gd php5-curl \
                       php5-common php5-cgi sqlite php-pear php-apc git-core \
                       autoconf automake autotools-dev curl libapr1 libtool curl libcurl4-openssl-dev \


### PR DESCRIPTION
Currently when you choose the nginx installation, Apache will be completely removed:
https://github.com/petrockblog/OwncloudPie/blob/b7849d2a494e19f5b82d2ac5d66dc387a2af7b0f/owncloudpie_setup.sh#L188

This doesn’t happen the other way around with the Apache installation. It also seems wrong, especially when Apache was installed for other apps, for example Wordpress (as it’s done in the [official documentation](http://www.raspberrypi.org/documentation/usage/wordpress/README.md)).

@petrockblog what do you think?
